### PR TITLE
first working version, for one link

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <!-- Avalonia packages -->
     <!-- Important: keep version in sync! -->
     <PackageVersion Include="Avalonia" Version="11.3.2" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.2" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.3.2" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.2" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.2" />

--- a/GetYaTube.Android/Properties/AndroidManifest.xml
+++ b/GetYaTube.Android/Properties/AndroidManifest.xml
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="auto">
 	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<application android:label="GetYaTube" android:icon="@drawable/Icon" />
 </manifest>

--- a/GetYaTube.Android/Services/AndroidPathService.cs
+++ b/GetYaTube.Android/Services/AndroidPathService.cs
@@ -1,0 +1,13 @@
+﻿using Android.OS;
+using GetYaTube.Services;
+
+namespace GetYaTube.Android.Services;
+
+public class AndroidPathService : IPathService
+{
+    public string GetDefaultDownloadPath()
+    {
+        // Gets the public "Music" directory on Android
+        return Environment.GetExternalStoragePublicDirectory(Environment.DirectoryMusic).AbsolutePath;
+    }
+}

--- a/GetYaTube.Desktop/GetYaTube.Desktop.csproj
+++ b/GetYaTube.Desktop/GetYaTube.Desktop.csproj
@@ -24,4 +24,13 @@
   <ItemGroup>
     <ProjectReference Include="..\GetYaTube\GetYaTube.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="ffprobe.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ffmpeg.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/GetYaTube.Desktop/Program.cs
+++ b/GetYaTube.Desktop/Program.cs
@@ -1,21 +1,56 @@
-﻿using System;
+﻿// GetYaTube.Desktop/Program.cs
 using Avalonia;
+using System;
+using GetYaTube.Services;
+using GetYaTube.ViewModels;
+using GetYaTube.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Splat;
+using Splat.Microsoft.Extensions.DependencyInjection;
 
 namespace GetYaTube.Desktop;
 
-sealed class Program
+class Program
 {
-    // Initialization code. Don't use any Avalonia, third-party APIs or any
-    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
-    // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        // 1. Create a service collection
+        var services = new ServiceCollection();
+        
+        // 2. Register all our services and viewmodels
+        ConfigureServices(services);
+        
+        // 3. THIS IS THE MAGIC LINE.
+        // It configures Splat to use the Microsoft DI container,
+        // handling the entire initialization lifecycle correctly.
+        // It MUST be called before building the App.
+        services.UseMicrosoftDependencyResolver();
+        
+        // 4. Now, build and run the app as normal.
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
 
-    // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
-            .WithInterFont()
-            .LogToTrace();
+            .LogToTrace()
+            .WithInterFont();
+
+    private static void ConfigureServices(IServiceCollection services)
+    {
+        // Register Platform-Specific Services
+        services.AddSingleton<IPathService, DesktopPathService>();
+
+        // Register Shared Services
+        services.AddSingleton<IYouTubeService, YouTubeService>();
+        services.AddSingleton<IConversionService, ConversionService>();
+
+        // Register ViewModels
+        services.AddTransient<MainViewModel>();
+        
+        // Register Views/Windows that need DI
+        services.AddTransient<MainWindow>();
+        services.AddTransient<MainView>();
+    }
 }

--- a/GetYaTube/App.axaml
+++ b/GetYaTube/App.axaml
@@ -11,5 +11,6 @@
 
     <Application.Styles>
         <FluentTheme />
+        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml"/>
     </Application.Styles>
 </Application>

--- a/GetYaTube/App.axaml.cs
+++ b/GetYaTube/App.axaml.cs
@@ -1,11 +1,16 @@
+using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core;
 using Avalonia.Data.Core.Plugins;
 using System.Linq;
 using Avalonia.Markup.Xaml;
+using GetYaTube.Services;
 using GetYaTube.ViewModels;
 using GetYaTube.Views;
+using Microsoft.Extensions.DependencyInjection;
+using Splat;
+using Splat.Microsoft.Extensions.DependencyInjection;
 
 namespace GetYaTube;
 
@@ -20,20 +25,12 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            // Avoid duplicate validations from both Avalonia and the CommunityToolkit. 
-            // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
-            DisableAvaloniaDataAnnotationValidation();
-            desktop.MainWindow = new MainWindow
-            {
-                DataContext = new MainViewModel()
-            };
+            // This now works because the Locator was correctly set up in Program.cs
+            desktop.MainWindow = Locator.Current.GetService<MainWindow>();
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleViewPlatform)
         {
-            singleViewPlatform.MainView = new MainView
-            {
-                DataContext = new MainViewModel()
-            };
+            singleViewPlatform.MainView = Locator.Current.GetService<MainView>();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/GetYaTube/GetYaTube.csproj
+++ b/GetYaTube/GetYaTube.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
@@ -24,9 +25,5 @@
     <PackageReference Include="Splat.Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Xabe.FFmpeg" />
     <PackageReference Include="YoutubeExplode" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Services\" />
   </ItemGroup>
 </Project>

--- a/GetYaTube/Models/VideoDownloadInfo.cs
+++ b/GetYaTube/Models/VideoDownloadInfo.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace GetYaTube.Models;
+
+public class VideoDownloadInfo
+{
+    public required string VideoId { get; init; }
+    public required string Title { get; init; }
+    public required string Author { get; init; }
+    public TimeSpan Duration { get; init; }
+}

--- a/GetYaTube/Services/ConversionService.cs
+++ b/GetYaTube/Services/ConversionService.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using GetYaTube.Models;
+using Xabe.FFmpeg;
+using YoutubeExplode;
+using YoutubeExplode.Videos.Streams;
+
+namespace GetYaTube.Services;
+
+public class ConversionService : IConversionService
+{
+    private readonly YoutubeClient _youtubeClient = new();
+
+    public ConversionService()
+    {
+        FFmpeg.SetExecutablesPath(AppContext.BaseDirectory);
+    }
+
+    public async Task ConvertAsync(VideoDownloadInfo videoInfo, string outputPath, AudioFormat format,
+        IProgress<double> progress)
+    {
+        var streamManifest = await _youtubeClient.Videos.Streams.GetManifestAsync(videoInfo.VideoId);
+        var audioStreamInfo = streamManifest.GetAudioOnlyStreams().GetWithHighestBitrate();
+        
+        var outputExtension = format == AudioFormat.Mp3 ? ".mp3" : ".flac";
+        var finalFilePath = Path.ChangeExtension(outputPath, outputExtension);
+
+        var conversion =
+            (IConversion)await FFmpeg.Conversions.FromSnippet.ExtractAudio(audioStreamInfo.Url, finalFilePath);
+
+        if (format == AudioFormat.Mp3)
+        {
+            conversion.SetAudioBitrate(192);
+        }
+
+        conversion.OnProgress += (sender, args) =>
+        {
+            progress.Report(args.Percent / 100.0);
+        };
+
+        await conversion.Start();
+    }
+}

--- a/GetYaTube/Services/DesktopPathService.cs
+++ b/GetYaTube/Services/DesktopPathService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.IO;
+
+namespace GetYaTube.Services;
+
+public class DesktopPathService : IPathService
+{
+    public string GetDefaultDownloadPath()
+    {
+        // Gets the user's "Downloads" folder
+        string? userProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+        if (string.IsNullOrEmpty(userProfile))
+            return Environment.GetFolderPath(Environment.SpecialFolder.MyMusic);
+        
+        return Path.Combine(userProfile, "Downloads");
+    }
+}

--- a/GetYaTube/Services/IConversionService.cs
+++ b/GetYaTube/Services/IConversionService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+using GetYaTube.Models;
+
+namespace GetYaTube.Services;
+
+
+public enum AudioFormat { Mp3, Flac }
+
+public interface IConversionService
+{
+    Task ConvertAsync(VideoDownloadInfo videoInfo, string outputPath, AudioFormat format, IProgress<double> progress);
+}

--- a/GetYaTube/Services/IPathService.cs
+++ b/GetYaTube/Services/IPathService.cs
@@ -1,0 +1,6 @@
+﻿namespace GetYaTube.Services;
+
+public interface IPathService
+{
+    string GetDefaultDownloadPath();
+}

--- a/GetYaTube/Services/IYouTubeService.cs
+++ b/GetYaTube/Services/IYouTubeService.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using GetYaTube.Models;
+
+namespace GetYaTube.Services;
+
+public interface IYouTubeService
+{
+    /// <summary>
+    /// Gets a single video's metadata
+    /// </summary>
+    /// <param name="url">link to youtube video</param>
+    /// <returns>Information of the source</returns>
+    Task<VideoDownloadInfo> GetVideoInfoAsync(string url);
+    
+    IAsyncEnumerable<VideoDownloadInfo> GetPlaylistInfoAsync(string url);
+}

--- a/GetYaTube/Services/YouTubeService.cs
+++ b/GetYaTube/Services/YouTubeService.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GetYaTube.Models;
+using YoutubeExplode;
+using YoutubeExplode.Videos;
+
+namespace GetYaTube.Services;
+
+public class YouTubeService : IYouTubeService
+{
+    private readonly YoutubeClient _youtubeClient = new();
+
+    public async Task<VideoDownloadInfo> GetVideoInfoAsync(string url)
+    {
+        var video = await _youtubeClient.Videos.GetAsync(url);
+        return MapVideoToDownloadInfo(video);
+    }
+
+    public async IAsyncEnumerable<VideoDownloadInfo> GetPlaylistInfoAsync(string url)
+    {
+        await foreach (var video in _youtubeClient.Playlists.GetVideosAsync(url))
+        {
+            yield return MapVideoToDownloadInfo(video);
+        }
+    }
+
+    private static VideoDownloadInfo MapVideoToDownloadInfo(IVideo video)
+    {
+        return new VideoDownloadInfo
+        {
+            VideoId = video.Id.Value,
+            Title = video.Title,
+            Author = video.Author.ChannelTitle,
+            Duration = video.Duration ?? TimeSpan.Zero
+        };
+    }
+}

--- a/GetYaTube/ViewModels/DownloadQueueItem.cs
+++ b/GetYaTube/ViewModels/DownloadQueueItem.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using GetYaTube.Models;
+
+namespace GetYaTube.ViewModels;
+
+public partial class DownloadQueueItem : ObservableObject
+{
+    // Store the video info we got from the YouTube service
+    public required VideoDownloadInfo VideoInfo { get; init; }
+
+    [ObservableProperty]
+    private string _title;
+    
+    [ObservableProperty]
+    private string _status;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ProgressDisplay))]
+    private double _progress;
+    
+    // A computed property for a nice display format (e.g., "75%")
+    public string ProgressDisplay => $"{Progress:P0}";
+    
+    [ObservableProperty]
+    private bool _isIndeterminate; // For when we're busy but don't have progress yet
+}

--- a/GetYaTube/ViewModels/MainViewModel.cs
+++ b/GetYaTube/ViewModels/MainViewModel.cs
@@ -1,9 +1,140 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using GetYaTube.Services;
 
 namespace GetYaTube.ViewModels;
 
+
 public partial class MainViewModel : ViewModelBase
 {
-    [ObservableProperty]
-    private string _greeting = "Welcome to Avalonia!";
+    private readonly IYouTubeService _youTubeService;
+    private readonly IConversionService _conversionService;
+    private readonly IPathService _pathService;
+
+    // --- Bindable Properties ---
+    [ObservableProperty] [NotifyCanExecuteChangedFor(nameof(ProcessUrlCommand))]
+    private string _url = string.Empty;
+
+    [ObservableProperty] private bool _isBusy;
+
+    [ObservableProperty] private string _statusMessage = "Ready";
+
+    public ObservableCollection<DownloadQueueItem> DownloadQueue { get; } = new();
+
+    public MainViewModel(IYouTubeService youTubeService, IConversionService conversionService, IPathService pathService)
+    {
+        _youTubeService = youTubeService;
+        _conversionService = conversionService;
+        _pathService = pathService;
+    }
+
+    private bool CanProcessUrl() => !string.IsNullOrWhiteSpace(Url) && !IsBusy;
+
+    [RelayCommand(CanExecute = nameof(CanProcessUrl))]
+    private async Task ProcessUrlAsync()
+    {
+        IsBusy = true;
+        StatusMessage = "Fetching video info...";
+        DownloadQueue.Clear();
+
+        try
+        {
+            var itemsToProcess = new List<DownloadQueueItem>();
+
+            // Check if it's a playlist or a single video
+            if (Url.Contains("playlist?list=", StringComparison.OrdinalIgnoreCase))
+            {
+                StatusMessage = "Fetching playlist videos...";
+                // Asynchronously stream playlist info without blocking the UI
+                await foreach (var videoInfo in _youTubeService.GetPlaylistInfoAsync(Url))
+                {
+                    var queueItem = new DownloadQueueItem
+                    {
+                        VideoInfo = videoInfo, // Store the full info object
+                        Title = videoInfo.Title,
+                        Status = "Queued",
+                        IsIndeterminate = true
+                    };
+                    DownloadQueue.Add(queueItem);
+                    itemsToProcess.Add(queueItem);
+                }
+            }
+            else // It's a single video
+            {
+                var videoInfo = await _youTubeService.GetVideoInfoAsync(Url);
+                var queueItem = new DownloadQueueItem
+                {
+                    VideoInfo = videoInfo,
+                    Title = videoInfo.Title,
+                    Status = "Queued",
+                    IsIndeterminate = true
+                };
+                DownloadQueue.Add(queueItem);
+                itemsToProcess.Add(queueItem);
+            }
+
+            StatusMessage = $"Processing {itemsToProcess.Count} item(s)...";
+
+            // Now, process each item in the queue one by one.
+            // For a more advanced app, you could run them in parallel.
+            foreach (var item in itemsToProcess)
+            {
+                await ProcessQueueItemAsync(item);
+            }
+
+            StatusMessage = "All items processed.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+    
+    private async Task ProcessQueueItemAsync(DownloadQueueItem item)
+    {
+        item.IsIndeterminate = false;
+        item.Status = "Downloading & Converting...";
+        item.Progress = 0;
+
+        try
+        {
+            // Get the default download path from our platform-specific service
+            var downloadFolder = _pathService.GetDefaultDownloadPath();
+        
+            // Ensure the directory exists
+            Directory.CreateDirectory(downloadFolder);
+
+            // Sanitize the video title to create a valid file name
+            var sanitizedTitle = string.Join("_", item.VideoInfo.Title.Split(Path.GetInvalidFileNameChars()));
+            var outputPath = Path.Combine(downloadFolder, sanitizedTitle);
+        
+            // Create a progress reporter that updates the item's Progress property
+            var progressHandler = new Progress<double>(p => item.Progress = p);
+
+            // TODO: Let the user choose the format. For now, we'll hardcode Mp3.
+            var format = AudioFormat.Mp3;
+
+            // Call the conversion service!
+            await _conversionService.ConvertAsync(item.VideoInfo, outputPath, format, progressHandler);
+
+            // If we get here, it succeeded
+            item.Progress = 1.0;
+            item.Status = "Completed";
+        }
+        catch (Exception ex)
+        {
+            // Handle any errors during the conversion
+            item.Progress = 0;
+            item.Status = $"Error: {ex.Message}";
+        }
+    }
 }

--- a/GetYaTube/Views/MainView.axaml
+++ b/GetYaTube/Views/MainView.axaml
@@ -2,15 +2,50 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="clr-namespace:GetYaTube.ViewModels"
+             xmlns:vm="using:GetYaTube.ViewModels"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="GetYaTube.Views.MainView"
              x:DataType="vm:MainViewModel">
-  <Design.DataContext>
-    <!-- This only sets the DataContext for the previewer in an IDE,
-         to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-    <vm:MainViewModel />
-  </Design.DataContext>
+    <Design.DataContext>
+        <!-- This allows the previewer to show data -->
+        <vm:MainViewModel/>
+    </Design.DataContext>
 
-  <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <Grid RowDefinitions="Auto,*,Auto" Margin="20">
+        <!-- Input Section -->
+        <StackPanel Grid.Row="0" Spacing="10">
+            <TextBlock Text="YouTube URL:" FontWeight="Bold"/>
+            <TextBox Text="{Binding Url, Mode=TwoWay}" Watermark="Enter a YouTube video or playlist URL"/>
+            <!-- TODO: Add controls for format selection (MP3/FLAC) -->
+            <Button Content="Process URL"
+                    Command="{Binding ProcessUrlCommand}"
+                    HorizontalAlignment="Stretch"
+                    Classes="accent"/>
+        </StackPanel>
+
+        <!-- Download Queue Section -->
+        <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1" Margin="0,15">
+            <DataGrid ItemsSource="{Binding DownloadQueue}" IsReadOnly="True" AutoGenerateColumns="False">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Title" Binding="{Binding Title}" Width="*"/>
+                    <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="150"/>
+                    <DataGridTemplateColumn Header="Progress" Width="200">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <ProgressBar Value="{Binding Progress}" 
+                                             Maximum="1.0"
+                                             IsIndeterminate="{Binding IsIndeterminate}" /> <!-- Add this line -->
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                </DataGrid.Columns>
+            </DataGrid>
+        </Border>
+
+        <!-- Status Bar Section -->
+        <Grid Grid.Row="2" ColumnDefinitions="*,Auto">
+            <TextBlock Grid.Column="0" Text="{Binding StatusMessage}" VerticalAlignment="Center"/>
+            <ProgressBar Grid.Column="1" Width="100" IsIndeterminate="{Binding IsBusy}" IsVisible="{Binding IsBusy}"/>
+        </Grid>
+    </Grid>
 </UserControl>

--- a/GetYaTube/Views/MainWindow.axaml.cs
+++ b/GetYaTube/Views/MainWindow.axaml.cs
@@ -1,11 +1,13 @@
 using Avalonia.Controls;
+using GetYaTube.ViewModels;
 
 namespace GetYaTube.Views;
 
 public partial class MainWindow : Window
 {
-    public MainWindow()
+    public MainWindow(MainViewModel viewModel)
     {
         InitializeComponent();
+        DataContext = viewModel;
     }
 }


### PR DESCRIPTION
feat(core): Implement single video download and conversion

This commit introduces the primary functionality of the application: converting a single YouTube video URL into an MP3 file.

It establishes the core service architecture:
- `IYouTubeService` (implemented with YoutubeExplode) is responsible for fetching video metadata.
- `IConversionService` (implemented with Xabe.FFmpeg) handles the download of the audio stream and conversion to the target format.
- `IPathService` provides a platform-agnostic way to determine the output directory.

The `MainViewModel` now orchestrates these services. When a URL is processed, it calls the services, reports progress to the UI via an `IProgress<double>` implementation, and handles success or error states. The UI displays the download item in a DataGrid with a live progress bar.